### PR TITLE
Further improve EELS demo notebook

### DIFF
--- a/electron_microscopy/EELS/EELS_analysis.ipynb
+++ b/electron_microscopy/EELS/EELS_analysis.ipynb
@@ -130,7 +130,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/home/magnunor/Documents/HyperSpy/hyperspy/io_plugins/tiff.py:31: UserWarning: Failed to import the optional scikit image package. Loading of some compressed images will be slow.\n",
+      "/home/magnunor/Documents/HyperSpy_project/HyperSpy/hyperspy/io_plugins/tiff.py:31: UserWarning: Failed to import the optional scikit image package. Loading of some compressed images will be slow.\n",
       "\n",
       "  \"Failed to import the optional scikit image package. \"\n"
      ]
@@ -149,7 +149,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -160,7 +160,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -178,20 +178,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " calculating 100% |#############################################| ETA:  00:00:00 \n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "s.remove_background()"
    ]
@@ -223,7 +214,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -234,27 +225,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " calculating 100% |#############################################| ETA:  00:00:00 \n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "s1 = s.remove_background(signal_range=(405.,448.))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -272,7 +254,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -283,7 +265,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -307,23 +289,59 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Firstly we'll have to tell HyperSpy where to find the Hartree-Slater cross section files, since they are not included in HyperSpy. Go to the \"EELS\" tab, then \"Model\", then set \"GOS directory\" to the \"H-S GOS Tables\" folder"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "hs.preferences.gui()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 140,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/magnunor/Documents/HyperSpy_project/HyperSpy/hyperspy/signals.py:54: VisibleDeprecationWarning: The Spectrum class will be deprecated from version 1.0.0 and replaced with Signal1D\n",
+      "  VisibleDeprecationWarning)\n"
+     ]
+    }
+   ],
    "source": [
     "s_ll = hs.load(\"datasets/LSMO_STO_linescan_low_loss.hdf5\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 141,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/magnunor/Documents/HyperSpy_project/HyperSpy/hyperspy/signals.py:54: VisibleDeprecationWarning: The Spectrum class will be deprecated from version 1.0.0 and replaced with Signal1D\n",
+      "  VisibleDeprecationWarning)\n"
+     ]
+    }
+   ],
    "source": [
     "s = hs.load(\"datasets/LSMO_STO_linescan.hdf5\")"
    ]
@@ -337,7 +355,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 142,
    "metadata": {
     "collapsed": false
    },
@@ -363,7 +381,7 @@
        "    └── signal_type = EELS"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 142,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -381,7 +399,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 143,
    "metadata": {
     "collapsed": false
    },
@@ -404,7 +422,25 @@
       "Q3:\t-1.000\n",
       "max:\t-1.000\n",
       " calculating 100% |#############################################| ETA:  00:00:00 \n",
+      "\n",
+      " calculating 100% |#############################################| ETA:  00:00:00 \n",
+      "\n",
+      " calculating 100% |#############################################| ETA:  00:00:00 \n",
+      "\n",
+      " calculating 100% |#############################################| ETA:  00:00:00 \n",
+      "\n",
+      " calculating 100% |#############################################| ETA:  00:00:00 \n",
       "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/magnunor/Documents/HyperSpy_project/HyperSpy/hyperspy/signals.py:54: VisibleDeprecationWarning: The Spectrum class will be deprecated from version 1.0.0 and replaced with Signal1D\n",
+      "  VisibleDeprecationWarning)\n",
+      "/home/magnunor/Documents/HyperSpy_project/HyperSpy/hyperspy/signals.py:132: VisibleDeprecationWarning: The Signal class will be deprecated from version 1.0.0 and replaced with BaseSignal\n",
+      "  VisibleDeprecationWarning)\n"
      ]
     }
    ],
@@ -421,7 +457,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 144,
    "metadata": {
     "collapsed": true
    },
@@ -439,11 +475,107 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 145,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/magnunor/Documents/HyperSpy_project/HyperSpy/hyperspy/models/eelsmodel.py:86: VisibleDeprecationWarning: Adding \"background\" to the user namespace. This feature will be removed in Hyperspy 1.0.\n",
+      "  VisibleDeprecationWarning)\n",
+      "/home/magnunor/Documents/HyperSpy_project/HyperSpy/hyperspy/signals.py:54: VisibleDeprecationWarning: The Spectrum class will be deprecated from version 1.0.0 and replaced with Signal1D\n",
+      "  VisibleDeprecationWarning)\n",
+      "/home/magnunor/Documents/HyperSpy_project/HyperSpy/hyperspy/signals.py:132: VisibleDeprecationWarning: The Signal class will be deprecated from version 1.0.0 and replaced with BaseSignal\n",
+      "  VisibleDeprecationWarning)\n",
+      "/home/magnunor/Documents/HyperSpy_project/HyperSpy/hyperspy/models/eelsmodel.py:188: VisibleDeprecationWarning: Adding \"Ti_L3\" to the user namespace. This feature will be removed in Hyperspy 1.0.\n",
+      "  VisibleDeprecationWarning)\n",
+      "/home/magnunor/Documents/HyperSpy_project/HyperSpy/hyperspy/models/eelsmodel.py:194: VisibleDeprecationWarning: Adding \"Ti\" to the user namespace. This feature will be removed in Hyperspy 1.0.\n",
+      "  VisibleDeprecationWarning)\n",
+      "/home/magnunor/Documents/HyperSpy_project/HyperSpy/hyperspy/models/eelsmodel.py:227: VisibleDeprecationWarning: Adding \"Ti_L2\" to the user namespace. This feature will be removed in Hyperspy 1.0.\n",
+      "  VisibleDeprecationWarning)\n",
+      "/home/magnunor/Documents/HyperSpy_project/HyperSpy/hyperspy/models/eelsmodel.py:227: VisibleDeprecationWarning: Adding \"Ti_L1\" to the user namespace. This feature will be removed in Hyperspy 1.0.\n",
+      "  VisibleDeprecationWarning)\n",
+      "/home/magnunor/Documents/HyperSpy_project/HyperSpy/hyperspy/models/eelsmodel.py:188: VisibleDeprecationWarning: Adding \"O_K\" to the user namespace. This feature will be removed in Hyperspy 1.0.\n",
+      "  VisibleDeprecationWarning)\n",
+      "/home/magnunor/Documents/HyperSpy_project/HyperSpy/hyperspy/models/eelsmodel.py:194: VisibleDeprecationWarning: Adding \"O\" to the user namespace. This feature will be removed in Hyperspy 1.0.\n",
+      "  VisibleDeprecationWarning)\n",
+      "/home/magnunor/Documents/HyperSpy_project/HyperSpy/hyperspy/models/eelsmodel.py:188: VisibleDeprecationWarning: Adding \"Mn_L3\" to the user namespace. This feature will be removed in Hyperspy 1.0.\n",
+      "  VisibleDeprecationWarning)\n",
+      "/home/magnunor/Documents/HyperSpy_project/HyperSpy/hyperspy/models/eelsmodel.py:194: VisibleDeprecationWarning: Adding \"Mn\" to the user namespace. This feature will be removed in Hyperspy 1.0.\n",
+      "  VisibleDeprecationWarning)\n",
+      "/home/magnunor/Documents/HyperSpy_project/HyperSpy/hyperspy/models/eelsmodel.py:227: VisibleDeprecationWarning: Adding \"Mn_L2\" to the user namespace. This feature will be removed in Hyperspy 1.0.\n",
+      "  VisibleDeprecationWarning)\n",
+      "/home/magnunor/Documents/HyperSpy_project/HyperSpy/hyperspy/models/eelsmodel.py:227: VisibleDeprecationWarning: Adding \"Mn_L1\" to the user namespace. This feature will be removed in Hyperspy 1.0.\n",
+      "  VisibleDeprecationWarning)\n",
+      "/home/magnunor/Documents/HyperSpy_project/HyperSpy/hyperspy/models/eelsmodel.py:188: VisibleDeprecationWarning: Adding \"La_M5\" to the user namespace. This feature will be removed in Hyperspy 1.0.\n",
+      "  VisibleDeprecationWarning)\n",
+      "/home/magnunor/Documents/HyperSpy_project/HyperSpy/hyperspy/models/eelsmodel.py:194: VisibleDeprecationWarning: Adding \"La\" to the user namespace. This feature will be removed in Hyperspy 1.0.\n",
+      "  VisibleDeprecationWarning)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Hartree-Slater GOS\n",
+      "\tElement:  Ti\n",
+      "\tSubshell:  L3\n",
+      "\tOnset Energy =  456.0\n",
+      "\n",
+      "Hartree-Slater GOS\n",
+      "\tElement:  Ti\n",
+      "\tSubshell:  L2\n",
+      "\tOnset Energy =  462.0\n",
+      "\n",
+      "Hartree-Slater GOS\n",
+      "\tElement:  Ti\n",
+      "\tSubshell:  L1\n",
+      "\tOnset Energy =  564.0\n",
+      "\n",
+      "Hartree-Slater GOS\n",
+      "\tElement:  O\n",
+      "\tSubshell:  K\n",
+      "\tOnset Energy =  532.0\n",
+      "\n",
+      "Hartree-Slater GOS\n",
+      "\tElement:  Mn\n",
+      "\tSubshell:  L3\n",
+      "\tOnset Energy =  640.0\n",
+      "\n",
+      "Hartree-Slater GOS\n",
+      "\tElement:  Mn\n",
+      "\tSubshell:  L2\n",
+      "\tOnset Energy =  651.0\n",
+      "\n",
+      "Hartree-Slater GOS\n",
+      "\tElement:  Mn\n",
+      "\tSubshell:  L1\n",
+      "\tOnset Energy =  769.0\n",
+      "\n",
+      "Hartree-Slater GOS\n",
+      "\tElement:  La\n",
+      "\tSubshell:  M5\n",
+      "\tOnset Energy =  832.0\n",
+      "\n",
+      "Hartree-Slater GOS\n",
+      "\tElement:  La\n",
+      "\tSubshell:  M4\n",
+      "\tOnset Energy =  849.0\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/magnunor/Documents/HyperSpy_project/HyperSpy/hyperspy/models/eelsmodel.py:227: VisibleDeprecationWarning: Adding \"La_M4\" to the user namespace. This feature will be removed in Hyperspy 1.0.\n",
+      "  VisibleDeprecationWarning)\n"
+     ]
+    }
+   ],
    "source": [
     "m = s.create_model(ll=s_ll)"
    ]
@@ -457,7 +589,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 146,
    "metadata": {
     "collapsed": false
    },
@@ -467,7 +599,7 @@
       "text/plain": [
        "   # |            Attribute Name |            Component Name |            Component Type\n",
        "---- | ------------------------- | ------------------------- | -------------------------\n",
-       "   0 |                  PowerLaw |                  PowerLaw |                  PowerLaw\n",
+       "   0 |                background |                background |                  PowerLaw\n",
        "   1 |                     Ti_L3 |                     Ti_L3 |                EELSCLEdge\n",
        "   2 |                     Ti_L2 |                     Ti_L2 |                EELSCLEdge\n",
        "   3 |                     Ti_L1 |                     Ti_L1 |                EELSCLEdge\n",
@@ -479,7 +611,7 @@
        "   9 |                     La_M4 |                     La_M4 |                EELSCLEdge"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 146,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -497,7 +629,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 147,
    "metadata": {
     "collapsed": false
    },
@@ -517,7 +649,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 159,
    "metadata": {
     "collapsed": false
    },
@@ -530,12 +662,60 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "We can check the error of the fitting"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 160,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "edges = (\"Ti_L3\", \"La_M5\", \"Mn_L3\",\"O_K\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 161,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/lib/python3/dist-packages/matplotlib/__init__.py:894: UserWarning: axes.color_cycle is deprecated and replaced with axes.prop_cycle; please use the latter.\n",
+      "  warnings.warn(self.msg_depr % (key, alt_key))\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.axes._subplots.AxesSubplot at 0x7fd3fdc454e0>"
+      ]
+     },
+     "execution_count": 161,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "hs.plot.plot_spectra([m[edge].intensity.as_signal(\"std\") for edge in edges], legend=edges)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "This fitted mostly ok, but it is still not very good. Firstly we can move the Hartree-Slater onsets interactively"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -553,7 +733,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 149,
    "metadata": {
     "collapsed": true
    },
@@ -571,7 +751,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 150,
    "metadata": {
     "collapsed": true
    },
@@ -589,7 +769,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 151,
    "metadata": {
     "collapsed": false
    },
@@ -597,10 +777,10 @@
     {
      "data": {
       "text/plain": [
-       "638.0"
+       "640.0"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 151,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -611,7 +791,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 152,
    "metadata": {
     "collapsed": false
    },
@@ -619,10 +799,10 @@
     {
      "data": {
       "text/plain": [
-       "649.5"
+       "651.0"
       ]
      },
-     "execution_count": 40,
+     "execution_count": 152,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -633,7 +813,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 153,
    "metadata": {
     "collapsed": false
    },
@@ -644,7 +824,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 154,
    "metadata": {
     "collapsed": false
    },
@@ -655,7 +835,7 @@
        "649.5"
       ]
      },
-     "execution_count": 44,
+     "execution_count": 154,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -666,7 +846,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 155,
    "metadata": {
     "collapsed": true
    },
@@ -685,35 +865,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 156,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Automatically changing the fine structure width of edge 1 from 30.0 eV to 4.0 eV to avoid conflicts with edge number 2\n",
+      "Automatically changing the fine structure width of edge 5 from 30.0 eV to 9.0 eV to avoid conflicts with edge number 6\n",
+      "Automatically changing the fine structure width of edge 8 from 30.0 eV to 15.0 eV to avoid conflicts with edge number 9\n"
+     ]
+    }
+   ],
    "source": [
     "m.enable_fine_structure()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 49,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "m.fix_fine_structure?"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 50,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "hs.preferences.gui()"
    ]
   },
   {
@@ -725,7 +893,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 157,
    "metadata": {
     "collapsed": false
    },
@@ -742,7 +910,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/home/magnunor/Documents/HyperSpy/hyperspy/model.py:795: RuntimeWarning: invalid value encountered in sqrt\n",
+      "/home/magnunor/Documents/HyperSpy_project/HyperSpy/hyperspy/model.py:1254: RuntimeWarning: invalid value encountered in sqrt\n",
       "  self.p_std = np.sqrt(np.diag(pcov))\n"
      ]
     },
@@ -750,7 +918,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " calculating  30% |#############                                | ETA:  00:02:13 "
+      " calculating 100% |#############################################| ETA:  00:00:00 \n",
+      "\n"
      ]
     }
    ],
@@ -767,7 +936,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 134,
    "metadata": {
     "collapsed": false
    },
@@ -780,40 +949,208 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we can can have a look at the intensity from the individual EELS-edges"
+    "Now we can can have a look at the relative intensity from the individual EELS-edges using plot_spectra"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 122,
    "metadata": {
     "collapsed": true
    },
    "outputs": [],
    "source": [
-    "m.components.Ti_L3.intensity.plot()"
+    "edges = (\"Ti_L3\", \"La_M5\", \"Mn_L3\",\"O_K\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 123,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/lib/python3/dist-packages/matplotlib/__init__.py:894: UserWarning: axes.color_cycle is deprecated and replaced with axes.prop_cycle; please use the latter.\n",
+      "  warnings.warn(self.msg_depr % (key, alt_key))\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.axes._subplots.AxesSubplot at 0x7fd3fdc10c88>"
+      ]
+     },
+     "execution_count": 123,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "hs.plot.plot_spectra([m[edge].intensity.as_signal() for edge in edges], legend=edges)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "While the fitting looks nice, we can clearly improve this. Firstly the intensites are negative where it should be zero. Secondly, the fine structure regions can be fine tuned. Especially the Mn-L1 fine structure window can be reduced"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 124,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "m.components.Mn_L1.fine_structure_width = 15"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To avoid the negative values we use bounded fitting, where we can constrain the parametern values between certain values. The bmin and bmax properties in the parameters are used for this."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 125,
    "metadata": {
     "collapsed": true
    },
    "outputs": [],
    "source": [
-    "m.components.La_M5.intensity.plot()"
+    "m.components.Mn_L3.intensity.bmin = 0.0"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 126,
    "metadata": {
     "collapsed": true
    },
    "outputs": [],
    "source": [
-    "m.components.Mn_L3.intensity.plot()"
+    "m.components.La_M5.intensity.bmin = 0.0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 127,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "m.components.Ti_L3.intensity.bmin = 0.0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 128,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "m.components.O_K.intensity.bmin = 0.0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Then we use the fitter='mpfit' and bounded=True arguments when running the multifitter"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 135,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "m.disable_fine_structure()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 136,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "m.ensure_parameters_in_bounds()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 137,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " calculating 100% |#############################################| ETA:  00:00:00 \n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "m.multifit(kind='smart', fitter='mpfit', bounded=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 138,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "m.plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 133,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/lib/python3/dist-packages/matplotlib/__init__.py:894: UserWarning: axes.color_cycle is deprecated and replaced with axes.prop_cycle; please use the latter.\n",
+      "  warnings.warn(self.msg_depr % (key, alt_key))\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.axes._subplots.AxesSubplot at 0x7fd3fe75b390>"
+      ]
+     },
+     "execution_count": 133,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "hs.plot.plot_spectra([m[edge].intensity.as_signal() for edge in edges], legend=edges)"
    ]
   },
   {

--- a/electron_microscopy/EELS/EELS_analysis.ipynb
+++ b/electron_microscopy/EELS/EELS_analysis.ipynb
@@ -110,7 +110,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -121,21 +121,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/magnunor/Documents/HyperSpy_project/HyperSpy/hyperspy/io_plugins/tiff.py:31: UserWarning: Failed to import the optional scikit image package. Loading of some compressed images will be slow.\n",
-      "\n",
-      "  \"Failed to import the optional scikit image package. \"\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import hyperspy.api as hs"
    ]
@@ -173,14 +163,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we can quantifiy the first edge (Ti-L23). Firstly by removing the background, then cropping the signal to only include the Ti-L23 edge"
+    "Now we can quantifiy the first edge (Ti-L23, 460 eV, 0-10 nm). Firstly by removing the background, then cropping the signal to only include the Ti-L23 edge. The remove_background box can disappear (known bug), if it does run the s.remove_background() command again."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "scrolled": true
    },
    "outputs": [],
    "source": [
@@ -202,7 +193,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note, both these functions replaced the old signals s."
+    "Note, both these functions replaced the old signal s."
    ]
   },
   {
@@ -308,40 +299,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 140,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/magnunor/Documents/HyperSpy_project/HyperSpy/hyperspy/signals.py:54: VisibleDeprecationWarning: The Spectrum class will be deprecated from version 1.0.0 and replaced with Signal1D\n",
-      "  VisibleDeprecationWarning)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "s_ll = hs.load(\"datasets/LSMO_STO_linescan_low_loss.hdf5\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 141,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/magnunor/Documents/HyperSpy_project/HyperSpy/hyperspy/signals.py:54: VisibleDeprecationWarning: The Spectrum class will be deprecated from version 1.0.0 and replaced with Signal1D\n",
-      "  VisibleDeprecationWarning)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "s = hs.load(\"datasets/LSMO_STO_linescan.hdf5\")"
    ]
@@ -355,37 +328,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 142,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "├── Acquisition_instrument\n",
-       "│   └── TEM\n",
-       "│       ├── Detector\n",
-       "│       │   └── EELS\n",
-       "│       │       └── collection_angle = 33.100000000000001\n",
-       "│       ├── beam_energy = 200.0\n",
-       "│       ├── convergence_angle = 27.100000000000001\n",
-       "│       └── dwell_time = 0.49990557338919173\n",
-       "├── General\n",
-       "│   ├── original_filename = LSMO_STO_linescan.dm3\n",
-       "│   └── title = EELS Spectrum Image (high-loss)\n",
-       "└── Signal\n",
-       "    ├── binned = True\n",
-       "    ├── record_by = spectrum\n",
-       "    ├── signal_origin = \n",
-       "    └── signal_type = EELS"
-      ]
-     },
-     "execution_count": 142,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "s.metadata"
    ]
@@ -394,56 +341,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Firstly, we make sure the energy scale is properly aligned by using the zero loss peak in the low loss spectrum."
+    "Firstly, we make sure the energy scale is properly aligned by using the zero loss peak in the low loss spectrum. The subpixel argument interpolates the data, so we get sub-pixel alignment. Using the also_align argument, we can also apply the alignment on a another signal. For example when using dualEELS, where both the low loss and core loss is acquired quasi-simultaneously. Note the other signals must have the same navigation shape as the low loss signals."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 143,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Initial ZLP position statistics\n",
-      "-------------------------------\n",
-      "Summary statistics\n",
-      "------------------\n",
-      "mean:\t-1.000\n",
-      "std:\t0.000\n",
-      "\n",
-      "min:\t-1.000\n",
-      "Q1:\t-1.000\n",
-      "median:\t-1.000\n",
-      "Q3:\t-1.000\n",
-      "max:\t-1.000\n",
-      " calculating 100% |#############################################| ETA:  00:00:00 \n",
-      "\n",
-      " calculating 100% |#############################################| ETA:  00:00:00 \n",
-      "\n",
-      " calculating 100% |#############################################| ETA:  00:00:00 \n",
-      "\n",
-      " calculating 100% |#############################################| ETA:  00:00:00 \n",
-      "\n",
-      " calculating 100% |#############################################| ETA:  00:00:00 \n",
-      "\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/magnunor/Documents/HyperSpy_project/HyperSpy/hyperspy/signals.py:54: VisibleDeprecationWarning: The Spectrum class will be deprecated from version 1.0.0 and replaced with Signal1D\n",
-      "  VisibleDeprecationWarning)\n",
-      "/home/magnunor/Documents/HyperSpy_project/HyperSpy/hyperspy/signals.py:132: VisibleDeprecationWarning: The Signal class will be deprecated from version 1.0.0 and replaced with BaseSignal\n",
-      "  VisibleDeprecationWarning)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "s_ll.align_zero_loss_peak(subpixel=True, also_align=[s])"
    ]
@@ -457,7 +364,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 144,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -475,107 +382,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 145,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/magnunor/Documents/HyperSpy_project/HyperSpy/hyperspy/models/eelsmodel.py:86: VisibleDeprecationWarning: Adding \"background\" to the user namespace. This feature will be removed in Hyperspy 1.0.\n",
-      "  VisibleDeprecationWarning)\n",
-      "/home/magnunor/Documents/HyperSpy_project/HyperSpy/hyperspy/signals.py:54: VisibleDeprecationWarning: The Spectrum class will be deprecated from version 1.0.0 and replaced with Signal1D\n",
-      "  VisibleDeprecationWarning)\n",
-      "/home/magnunor/Documents/HyperSpy_project/HyperSpy/hyperspy/signals.py:132: VisibleDeprecationWarning: The Signal class will be deprecated from version 1.0.0 and replaced with BaseSignal\n",
-      "  VisibleDeprecationWarning)\n",
-      "/home/magnunor/Documents/HyperSpy_project/HyperSpy/hyperspy/models/eelsmodel.py:188: VisibleDeprecationWarning: Adding \"Ti_L3\" to the user namespace. This feature will be removed in Hyperspy 1.0.\n",
-      "  VisibleDeprecationWarning)\n",
-      "/home/magnunor/Documents/HyperSpy_project/HyperSpy/hyperspy/models/eelsmodel.py:194: VisibleDeprecationWarning: Adding \"Ti\" to the user namespace. This feature will be removed in Hyperspy 1.0.\n",
-      "  VisibleDeprecationWarning)\n",
-      "/home/magnunor/Documents/HyperSpy_project/HyperSpy/hyperspy/models/eelsmodel.py:227: VisibleDeprecationWarning: Adding \"Ti_L2\" to the user namespace. This feature will be removed in Hyperspy 1.0.\n",
-      "  VisibleDeprecationWarning)\n",
-      "/home/magnunor/Documents/HyperSpy_project/HyperSpy/hyperspy/models/eelsmodel.py:227: VisibleDeprecationWarning: Adding \"Ti_L1\" to the user namespace. This feature will be removed in Hyperspy 1.0.\n",
-      "  VisibleDeprecationWarning)\n",
-      "/home/magnunor/Documents/HyperSpy_project/HyperSpy/hyperspy/models/eelsmodel.py:188: VisibleDeprecationWarning: Adding \"O_K\" to the user namespace. This feature will be removed in Hyperspy 1.0.\n",
-      "  VisibleDeprecationWarning)\n",
-      "/home/magnunor/Documents/HyperSpy_project/HyperSpy/hyperspy/models/eelsmodel.py:194: VisibleDeprecationWarning: Adding \"O\" to the user namespace. This feature will be removed in Hyperspy 1.0.\n",
-      "  VisibleDeprecationWarning)\n",
-      "/home/magnunor/Documents/HyperSpy_project/HyperSpy/hyperspy/models/eelsmodel.py:188: VisibleDeprecationWarning: Adding \"Mn_L3\" to the user namespace. This feature will be removed in Hyperspy 1.0.\n",
-      "  VisibleDeprecationWarning)\n",
-      "/home/magnunor/Documents/HyperSpy_project/HyperSpy/hyperspy/models/eelsmodel.py:194: VisibleDeprecationWarning: Adding \"Mn\" to the user namespace. This feature will be removed in Hyperspy 1.0.\n",
-      "  VisibleDeprecationWarning)\n",
-      "/home/magnunor/Documents/HyperSpy_project/HyperSpy/hyperspy/models/eelsmodel.py:227: VisibleDeprecationWarning: Adding \"Mn_L2\" to the user namespace. This feature will be removed in Hyperspy 1.0.\n",
-      "  VisibleDeprecationWarning)\n",
-      "/home/magnunor/Documents/HyperSpy_project/HyperSpy/hyperspy/models/eelsmodel.py:227: VisibleDeprecationWarning: Adding \"Mn_L1\" to the user namespace. This feature will be removed in Hyperspy 1.0.\n",
-      "  VisibleDeprecationWarning)\n",
-      "/home/magnunor/Documents/HyperSpy_project/HyperSpy/hyperspy/models/eelsmodel.py:188: VisibleDeprecationWarning: Adding \"La_M5\" to the user namespace. This feature will be removed in Hyperspy 1.0.\n",
-      "  VisibleDeprecationWarning)\n",
-      "/home/magnunor/Documents/HyperSpy_project/HyperSpy/hyperspy/models/eelsmodel.py:194: VisibleDeprecationWarning: Adding \"La\" to the user namespace. This feature will be removed in Hyperspy 1.0.\n",
-      "  VisibleDeprecationWarning)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Hartree-Slater GOS\n",
-      "\tElement:  Ti\n",
-      "\tSubshell:  L3\n",
-      "\tOnset Energy =  456.0\n",
-      "\n",
-      "Hartree-Slater GOS\n",
-      "\tElement:  Ti\n",
-      "\tSubshell:  L2\n",
-      "\tOnset Energy =  462.0\n",
-      "\n",
-      "Hartree-Slater GOS\n",
-      "\tElement:  Ti\n",
-      "\tSubshell:  L1\n",
-      "\tOnset Energy =  564.0\n",
-      "\n",
-      "Hartree-Slater GOS\n",
-      "\tElement:  O\n",
-      "\tSubshell:  K\n",
-      "\tOnset Energy =  532.0\n",
-      "\n",
-      "Hartree-Slater GOS\n",
-      "\tElement:  Mn\n",
-      "\tSubshell:  L3\n",
-      "\tOnset Energy =  640.0\n",
-      "\n",
-      "Hartree-Slater GOS\n",
-      "\tElement:  Mn\n",
-      "\tSubshell:  L2\n",
-      "\tOnset Energy =  651.0\n",
-      "\n",
-      "Hartree-Slater GOS\n",
-      "\tElement:  Mn\n",
-      "\tSubshell:  L1\n",
-      "\tOnset Energy =  769.0\n",
-      "\n",
-      "Hartree-Slater GOS\n",
-      "\tElement:  La\n",
-      "\tSubshell:  M5\n",
-      "\tOnset Energy =  832.0\n",
-      "\n",
-      "Hartree-Slater GOS\n",
-      "\tElement:  La\n",
-      "\tSubshell:  M4\n",
-      "\tOnset Energy =  849.0\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/magnunor/Documents/HyperSpy_project/HyperSpy/hyperspy/models/eelsmodel.py:227: VisibleDeprecationWarning: Adding \"La_M4\" to the user namespace. This feature will be removed in Hyperspy 1.0.\n",
-      "  VisibleDeprecationWarning)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "m = s.create_model(ll=s_ll)"
    ]
@@ -589,33 +400,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 146,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "   # |            Attribute Name |            Component Name |            Component Type\n",
-       "---- | ------------------------- | ------------------------- | -------------------------\n",
-       "   0 |                background |                background |                  PowerLaw\n",
-       "   1 |                     Ti_L3 |                     Ti_L3 |                EELSCLEdge\n",
-       "   2 |                     Ti_L2 |                     Ti_L2 |                EELSCLEdge\n",
-       "   3 |                     Ti_L1 |                     Ti_L1 |                EELSCLEdge\n",
-       "   4 |                       O_K |                       O_K |                EELSCLEdge\n",
-       "   5 |                     Mn_L3 |                     Mn_L3 |                EELSCLEdge\n",
-       "   6 |                     Mn_L2 |                     Mn_L2 |                EELSCLEdge\n",
-       "   7 |                     Mn_L1 |                     Mn_L1 |                EELSCLEdge\n",
-       "   8 |                     La_M5 |                     La_M5 |                EELSCLEdge\n",
-       "   9 |                     La_M4 |                     La_M4 |                EELSCLEdge"
-      ]
-     },
-     "execution_count": 146,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "m.components"
    ]
@@ -629,27 +418,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 147,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " calculating 100% |#############################################| ETA:  00:00:00 \n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "m.multifit(kind='smart')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 159,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -667,7 +447,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 160,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -678,30 +458,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 161,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/usr/lib/python3/dist-packages/matplotlib/__init__.py:894: UserWarning: axes.color_cycle is deprecated and replaced with axes.prop_cycle; please use the latter.\n",
-      "  warnings.warn(self.msg_depr % (key, alt_key))\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<matplotlib.axes._subplots.AxesSubplot at 0x7fd3fdc454e0>"
-      ]
-     },
-     "execution_count": 161,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "hs.plot.plot_spectra([m[edge].intensity.as_signal(\"std\") for edge in edges], legend=edges)"
    ]
@@ -733,7 +494,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 149,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -751,7 +512,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 150,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -769,51 +530,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 151,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "640.0"
-      ]
-     },
-     "execution_count": 151,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "m.components.Mn_L3.onset_energy.value"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 152,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "651.0"
-      ]
-     },
-     "execution_count": 152,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "m.components.Mn_L2.onset_energy.value"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 153,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -824,29 +563,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 154,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "649.5"
-      ]
-     },
-     "execution_count": 154,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "m.components.Mn_L2.onset_energy.value "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 155,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -865,21 +593,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 156,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Automatically changing the fine structure width of edge 1 from 30.0 eV to 4.0 eV to avoid conflicts with edge number 2\n",
-      "Automatically changing the fine structure width of edge 5 from 30.0 eV to 9.0 eV to avoid conflicts with edge number 6\n",
-      "Automatically changing the fine structure width of edge 8 from 30.0 eV to 15.0 eV to avoid conflicts with edge number 9\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "m.enable_fine_structure()"
    ]
@@ -893,36 +611,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 157,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      " calculating   0% |                                             | ETA:  --:--:-- "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/magnunor/Documents/HyperSpy_project/HyperSpy/hyperspy/model.py:1254: RuntimeWarning: invalid value encountered in sqrt\n",
-      "  self.p_std = np.sqrt(np.diag(pcov))\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " calculating 100% |#############################################| ETA:  00:00:00 \n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "m.multifit(kind='smart')"
    ]
@@ -936,7 +629,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 134,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -954,7 +647,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 122,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -965,30 +658,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 123,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/usr/lib/python3/dist-packages/matplotlib/__init__.py:894: UserWarning: axes.color_cycle is deprecated and replaced with axes.prop_cycle; please use the latter.\n",
-      "  warnings.warn(self.msg_depr % (key, alt_key))\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<matplotlib.axes._subplots.AxesSubplot at 0x7fd3fdc10c88>"
-      ]
-     },
-     "execution_count": 123,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "hs.plot.plot_spectra([m[edge].intensity.as_signal() for edge in edges], legend=edges)"
    ]
@@ -997,12 +671,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "While the fitting looks nice, we can clearly improve this. Firstly the intensites are negative where it should be zero. Secondly, the fine structure regions can be fine tuned. Especially the Mn-L1 fine structure window can be reduced"
+    "While the fitting looks nicer, we can clearly improve this. Firstly the intensites are negative where it should be zero. Secondly, the fine structure regions can be fine tuned. Especially the Mn-L1 fine structure window can be reduced"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 124,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -1020,7 +694,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 125,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -1031,7 +705,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 126,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -1042,7 +716,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 127,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -1053,7 +727,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 128,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -1066,12 +740,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Then we use the fitter='mpfit' and bounded=True arguments when running the multifitter"
+    "Then we use the fitter='mpfit' and bounded=True arguments when running the multifitter. DOES NOT WORK ATM DUE TO BUG!"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 135,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -1082,7 +756,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 136,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -1093,28 +767,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 137,
+   "execution_count": null,
    "metadata": {
     "collapsed": false,
     "scrolled": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " calculating 100% |#############################################| ETA:  00:00:00 \n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "m.multifit(kind='smart', fitter='mpfit', bounded=True)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 138,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -1125,30 +790,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 133,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/usr/lib/python3/dist-packages/matplotlib/__init__.py:894: UserWarning: axes.color_cycle is deprecated and replaced with axes.prop_cycle; please use the latter.\n",
-      "  warnings.warn(self.msg_depr % (key, alt_key))\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<matplotlib.axes._subplots.AxesSubplot at 0x7fd3fe75b390>"
-      ]
-     },
-     "execution_count": 133,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "hs.plot.plot_spectra([m[edge].intensity.as_signal() for edge in edges], legend=edges)"
    ]
@@ -1207,7 +853,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
@@ -1272,7 +918,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
@@ -1374,7 +1020,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Having had a qualitativily look at the data, we can try to quantify some of these changes. We do this by making making a model of the oxygen-K edge signal. As we've already removed the background, we set `auto_background=False`."
+    "Having had a qualitativily look at the data, we can try to quantify some of these changes. We do this by making making a model of the oxygen-K edge signal. As we've already removed the background, we set `auto_background=False`. In addition, since we haven't added any elements to the signal, we got no ionization edges."
    ]
   },
   {
@@ -1493,7 +1139,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Using the same method we can also fit the second largest peak between 535 and 541 eV"
+    "Using the same method we can also fit the second largest peak between 535 and 541 eV. Using the signal_range argument we don't have to select the region using the GUI."
    ]
   },
   {
@@ -1526,7 +1172,18 @@
    },
    "outputs": [],
    "source": [
-    "m.fit_component(g2)"
+    "m.fit_component(g2, signal_range=(535.,541.), only_current=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "m.plot()"
    ]
   },
   {
@@ -1653,7 +1310,7 @@
    },
    "outputs": [],
    "source": [
-    "m.fit_component(g3)"
+    "m.fit_component(g3, signal_range=(522., 527.), only_current=False)"
    ]
   },
   {
@@ -1671,7 +1328,36 @@
    },
    "outputs": [],
    "source": [
-    "m.set_signal_range()"
+    "m.set_signal_range(520.,541.)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And set the g1 and g2 components free"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "g1.set_parameters_free()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "g2.set_parameters_free()"
    ]
   },
   {
@@ -1718,7 +1404,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Then we can save the sigma of the different components as signals:"
+    "We can then compare the different parameters in the components"
    ]
   },
   {
@@ -1729,7 +1415,18 @@
    },
    "outputs": [],
    "source": [
-    "s_g1s = g1.sigma.as_signal()"
+    "g1_g3_ratio = g1.A.as_signal()/g3.A.as_signal()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "g1_g3_ratio.plot()"
    ]
   },
   {
@@ -1740,7 +1437,7 @@
    },
    "outputs": [],
    "source": [
-    "s_g2s = g2.sigma.as_signal()"
+    "g1_g3_position = g1.centre.as_signal()-g3.centre.as_signal()"
    ]
   },
   {
@@ -1751,7 +1448,36 @@
    },
    "outputs": [],
    "source": [
-    "s_g3s = g3.sigma.as_signal()"
+    "g1_g3_position.plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "g1_g3_sigma = g1.sigma.as_signal()/g3.sigma.as_signal()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "g1_g3_sigma.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In all of the comparisons there are some large changes in the regions with beam damage. However, the values can vary a great deal. This is most likely due to the g1 fitted to the pre-peak is not so clearly defined in these regions. Leading to potentially bad fitting."
    ]
   }
  ],

--- a/electron_microscopy/EELS/EELS_analysis.ipynb
+++ b/electron_microscopy/EELS/EELS_analysis.ipynb
@@ -91,6 +91,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "The datasets has been binned to reduce the file size and processing time."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# <a id='simple_quant'></a> 2. Simple quantification\n"
    ]
   },
@@ -98,12 +105,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Firstly we use some Jupyter magic to import the right plotting libraries, then import HyperSpy"
+    "Firstly we use some IPython magic to import the right plotting libraries, then import HyperSpy"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {
     "collapsed": true
    },
@@ -114,11 +121,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/magnunor/Documents/HyperSpy/hyperspy/io_plugins/tiff.py:31: UserWarning: Failed to import the optional scikit image package. Loading of some compressed images will be slow.\n",
+      "\n",
+      "  \"Failed to import the optional scikit image package. \"\n"
+     ]
+    }
+   ],
    "source": [
     "import hyperspy.api as hs"
    ]
@@ -132,7 +149,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {
     "collapsed": false
    },
@@ -143,7 +160,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {
     "collapsed": false
    },
@@ -156,16 +173,25 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we can quantifiy the first edge (Ti-L23). Firstly by removing the plasmon background, then cropping the signal to only include the Ti-L23 edge"
+    "Now we can quantifiy the first edge (Ti-L23). Firstly by removing the background, then cropping the signal to only include the Ti-L23 edge"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " calculating 100% |#############################################| ETA:  00:00:00 \n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "s.remove_background()"
    ]
@@ -185,23 +211,79 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Then we can sum the energy axis to get the relative Ti-content"
+    "Note, both these functions replaced the old signals s."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also do this using only the command line, which does not replace the original signal:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {
     "collapsed": false
    },
    "outputs": [],
    "source": [
-    "s_ti = s.sum(-1)"
+    "s = hs.load(\"datasets/LSMO_STO_linescan.hdf5\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " calculating 100% |#############################################| ETA:  00:00:00 \n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "s1 = s.remove_background(signal_range=(405.,448.))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "s2 = s1.isig[448.:480.]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Then we can sum the energy loss axis to get the relative Ti-content"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "s_ti = s2.sum(\"Energy loss\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
    "metadata": {
     "collapsed": false
    },
@@ -226,7 +308,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {
     "collapsed": false
    },
@@ -237,9 +319,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -255,11 +337,37 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "├── Acquisition_instrument\n",
+       "│   └── TEM\n",
+       "│       ├── Detector\n",
+       "│       │   └── EELS\n",
+       "│       │       └── collection_angle = 33.100000000000001\n",
+       "│       ├── beam_energy = 200.0\n",
+       "│       ├── convergence_angle = 27.100000000000001\n",
+       "│       └── dwell_time = 0.49990557338919173\n",
+       "├── General\n",
+       "│   ├── original_filename = LSMO_STO_linescan.dm3\n",
+       "│   └── title = EELS Spectrum Image (high-loss)\n",
+       "└── Signal\n",
+       "    ├── binned = True\n",
+       "    ├── record_by = spectrum\n",
+       "    ├── signal_origin = \n",
+       "    └── signal_type = EELS"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "s.metadata"
    ]
@@ -273,11 +381,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Initial ZLP position statistics\n",
+      "-------------------------------\n",
+      "Summary statistics\n",
+      "------------------\n",
+      "mean:\t-1.000\n",
+      "std:\t0.000\n",
+      "\n",
+      "min:\t-1.000\n",
+      "Q1:\t-1.000\n",
+      "median:\t-1.000\n",
+      "Q3:\t-1.000\n",
+      "max:\t-1.000\n",
+      " calculating 100% |#############################################| ETA:  00:00:00 \n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "s_ll.align_zero_loss_peak(subpixel=True, also_align=[s])"
    ]
@@ -291,7 +421,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {
     "collapsed": true
    },
@@ -309,7 +439,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {
     "collapsed": false
    },
@@ -327,11 +457,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "   # |            Attribute Name |            Component Name |            Component Type\n",
+       "---- | ------------------------- | ------------------------- | -------------------------\n",
+       "   0 |                  PowerLaw |                  PowerLaw |                  PowerLaw\n",
+       "   1 |                     Ti_L3 |                     Ti_L3 |                EELSCLEdge\n",
+       "   2 |                     Ti_L2 |                     Ti_L2 |                EELSCLEdge\n",
+       "   3 |                     Ti_L1 |                     Ti_L1 |                EELSCLEdge\n",
+       "   4 |                       O_K |                       O_K |                EELSCLEdge\n",
+       "   5 |                     Mn_L3 |                     Mn_L3 |                EELSCLEdge\n",
+       "   6 |                     Mn_L2 |                     Mn_L2 |                EELSCLEdge\n",
+       "   7 |                     Mn_L1 |                     Mn_L1 |                EELSCLEdge\n",
+       "   8 |                     La_M5 |                     La_M5 |                EELSCLEdge\n",
+       "   9 |                     La_M4 |                     La_M4 |                EELSCLEdge"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "m.components"
    ]
@@ -345,20 +497,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " calculating 100% |#############################################| ETA:  00:00:00 \n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "m.multifit(kind='smart')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
@@ -369,19 +530,190 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This fitted mostly ok, but it is still not very good. This is due to the fine structure not currently taken into account by the model. To get a good fit, we can either not fit to the fine structure regions, or model them somehow.\n",
+    "This fitted mostly ok, but it is still not very good. Firstly we can move the Hartree-Slater onsets interactively"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "m.enable_adjust_position()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Or manually, by directly changing the parameters within the Hartree-Slater edges. The parameter is called onset_energy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "m.components.O_K.onset_energy.value = 528"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "However, to change it for all the probe positions we have to use assign_current_value_to_all()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "m.components.O_K.onset_energy.assign_current_value_to_all()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We repeat this for the Manganese edges. Since this is an L-edge, there are 3 different ones. However, we only have to set the Mn-L3: the L2 and L1 is a set to an energy relative to the L3."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "638.0"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "m.components.Mn_L3.onset_energy.value"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "649.5"
+      ]
+     },
+     "execution_count": 40,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "m.components.Mn_L2.onset_energy.value"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "m.components.Mn_L3.onset_energy.value = 638.5"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "649.5"
+      ]
+     },
+     "execution_count": 44,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "m.components.Mn_L2.onset_energy.value "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "m.components.Mn_L3.onset_energy.assign_current_value_to_all()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is due to the fine structure not currently taken into account by the model. To get a good fit, we can either not fit to the fine structure regions, or model them somehow.\n",
     "The easiest way is defining certain regions as fine structure:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 51,
    "metadata": {
     "collapsed": false
    },
    "outputs": [],
    "source": [
     "m.enable_fine_structure()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "m.fix_fine_structure?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "hs.preferences.gui()"
    ]
   },
   {
@@ -397,7 +729,31 @@
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      " calculating   0% |                                             | ETA:  --:--:-- "
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/magnunor/Documents/HyperSpy/hyperspy/model.py:795: RuntimeWarning: invalid value encountered in sqrt\n",
+      "  self.p_std = np.sqrt(np.diag(pcov))\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " calculating  30% |#############                                | ETA:  00:02:13 "
+     ]
+    }
+   ],
    "source": [
     "m.multifit(kind='smart')"
    ]


### PR DESCRIPTION
Improvements based on feedback from https://github.com/hyperspy/hyperspy-demos/pull/10#issuecomment-223609434.

I implemented most of the changes, some comments on the rest:

> Could you use estimate_poissonian_noise_variance in order to run weighted lest squares?

I've never actually done this, will take a look at this tomorrow.

> You get negative values for the intensities when the expected value is 0, could you run bounded optimisation after showing the issue to improve the result?

Due to the bug in https://github.com/hyperspy/hyperspy/issues/1062, this does not seem to work with the fine structure enabled.

> Wouldn't it be better to keep the background for the fine structure modelling?

For the fine structure fitting, I prefer to fit as few components as possible at a time. Since it (in my experience) produces less variable results due to fewer components, and makes it a lot easier to compare the fine structure between different probe positions.

> Wouldn't it be better to add the gaussians on top of the O K edge? If that doesn't work, you could enable the fine structure and fix it to zero on the area where you're fitting gaussians and then fit a wider spectral range, which should result in a more accurate result.

I don't really like using the O-K edge, due to the difficultly in setting the onset and intensity in a robust fashion. This is due to the O-K fine structure changing a great deal between different materials and coordinations within the same material. So I find quantifying the fine structure changes much easier the fewer components are involved.