### PR TITLE
Use `--current-env` with nbval to ensure kernel

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
-addopts = --nbval-lax
+addopts = --nbval-lax --current-env
 usefixtures = tmpdir


### PR DESCRIPTION
Run tests with the same python that was used to run py.test.