### PR TITLE
Enable binder.org live demos

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,7 @@
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - matplotlib
+  - hyperspy
+  - hyperspy-gui-ipywidgets


### PR DESCRIPTION
This PR adds the appropriate `environment.yml` file to enable building of a Docker environment on binder.org, which allows for the demos to be viewed in an interactive environment.

For an example of it in action on my fork, see here: https://mybinder.org/v2/gh/jat255/hyperspy-demos/ENH_binderdotorg
