### PR TITLE
More binder documenation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,17 @@
 hyperspy-demos
 ==============
+[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/hyperspy/hyperspy-demos/master)
 
-HyperSpy IPython Notebook demos.
+HyperSpy Notebook demos.
 
-Follow [this link](http://nbviewer.ipython.org/github/hyperspy/hyperspy-demos/tree/master/)
-to display the demos with the [nbviewer](http://nbviewer.ipython.org).
+Follow [this link](https://mybinder.org/v2/gh/hyperspy/hyperspy-demos/master)
+to run the the demos with the [mybinder.org](https://mybinder.org/). 
+The demos will run remotely, and one can experiment with HyperSpy in a
+Jupyter notebook with no need to install or configure any software.
 
-To test the demo Notebooks, install [nbval](http://github.com/computationalmodelling/nbval)
+To test the demo notebooks locally, 
+clone the repository to your local machine, install HyperSpy,
+[nbval](http://github.com/computationalmodelling/nbval),
 and run py.test. To help visualize differences/errors, install
 [nbdime](http://github.com/jupyter/nbdime) as well, and run the test with
 `py.test --nbdime`.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 hyperspy-demos
 ==============
-[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/hyperspy/hyperspy-demos/master)
+[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/hyperspy/hyperspy-demos/master) [![Documentation Status](https://readthedocs.org/projects/hyperspy/badge/?version=stable)](http://hyperspy.readthedocs.io/en/stable/?badge=stable)
 
 HyperSpy Notebook demos.
 
 Follow [this link](https://mybinder.org/v2/gh/hyperspy/hyperspy-demos/master)
-to run the the demos with the [mybinder.org](https://mybinder.org/). 
+to run the the demos on [mybinder.org](https://mybinder.org/). 
 The demos will run remotely, and one can experiment with HyperSpy in a
-Jupyter notebook with no need to install or configure any software.
+Jupyter notebook with no need to install or configure any software locally.
 
 To test the demo notebooks locally, 
 clone the repository to your local machine, install HyperSpy,


### PR DESCRIPTION
Partially resolves #43.

This PR adds badges for the binder and documentation to the hyperspy-demos Readme, and updates the text of the Readme to explain how it works.