### PR TITLE
 Fix issue with recent version of nbformat

### DIFF
--- a/2_SVD_and_BSS.ipynb
+++ b/2_SVD_and_BSS.ipynb
@@ -124,7 +124,10 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -176,7 +179,10 @@
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -1789,7 +1795,10 @@
    "cell_type": "code",
    "execution_count": 9,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -2657,7 +2666,10 @@
    "cell_type": "code",
    "execution_count": 10,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -2682,7 +2694,10 @@
    "cell_type": "code",
    "execution_count": 11,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -7547,7 +7562,10 @@
    "cell_type": "code",
    "execution_count": 16,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -9980,7 +9998,10 @@
    "cell_type": "code",
    "execution_count": 19,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -13239,7 +13260,10 @@
    "cell_type": "code",
    "execution_count": 23,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -18064,7 +18088,10 @@
    "cell_type": "code",
    "execution_count": 27,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -19671,7 +19698,10 @@
    "cell_type": "code",
    "execution_count": 29,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -20508,7 +20538,10 @@
    "cell_type": "code",
    "execution_count": 31,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -22164,7 +22197,10 @@
    "cell_type": "code",
    "execution_count": 35,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -24604,7 +24640,10 @@
    "cell_type": "code",
    "execution_count": 38,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -24615,7 +24654,10 @@
    "cell_type": "code",
    "execution_count": 39,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -27064,7 +27106,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -27089,7 +27134,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.0"
+   "version": "3.7.6"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {
@@ -29612,5 +29657,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/Fitting_tutorial.ipynb
+++ b/Fitting_tutorial.ipynb
@@ -9734,7 +9734,10 @@
    "cell_type": "code",
    "execution_count": 36,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -10601,7 +10604,10 @@
    "cell_type": "code",
    "execution_count": 39,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -10657,7 +10663,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -10741,7 +10750,10 @@
    "cell_type": "code",
    "execution_count": 7,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -10784,7 +10796,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": []
@@ -10792,9 +10807,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Anaconda 3 (root)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "root"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -10806,7 +10821,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.0"
+   "version": "3.7.6"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {
@@ -14863,5 +14878,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/electron_microscopy/EDS/SEM_EDS_4D_visualisation.ipynb
+++ b/electron_microscopy/EDS/SEM_EDS_4D_visualisation.ipynb
@@ -33,7 +33,10 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -1868,7 +1871,10 @@
    "cell_type": "code",
    "execution_count": 8,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -1879,7 +1885,10 @@
    "cell_type": "code",
    "execution_count": 9,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -1945,7 +1954,10 @@
    "cell_type": "code",
    "execution_count": 11,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -1977,7 +1989,10 @@
    "cell_type": "code",
    "execution_count": 13,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -3617,7 +3632,10 @@
    "cell_type": "code",
    "execution_count": 15,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -3628,7 +3646,10 @@
    "cell_type": "code",
    "execution_count": 16,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -5296,7 +5317,10 @@
    "cell_type": "code",
    "execution_count": 23,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -5381,7 +5405,10 @@
    "cell_type": "code",
    "execution_count": 26,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -5393,7 +5420,10 @@
    "cell_type": "code",
    "execution_count": 27,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -5466,7 +5496,10 @@
    "cell_type": "code",
    "execution_count": 20,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -7160,7 +7193,10 @@
    "cell_type": "code",
    "execution_count": 25,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -7981,7 +8017,10 @@
    "cell_type": "code",
    "execution_count": 27,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -9628,7 +9667,10 @@
    "cell_type": "code",
    "execution_count": 30,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -9647,7 +9689,10 @@
    "cell_type": "code",
    "execution_count": 31,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -9694,7 +9739,10 @@
    "cell_type": "code",
    "execution_count": 33,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -10515,7 +10563,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": []
@@ -10537,7 +10588,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.0"
+   "version": "3.7.6"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {
@@ -13674,5 +13725,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
Saving the notebook containing widgets using the "classic" jupyter notebook failed with recent version of nbformat. As a workaround it is possible to save it using jupyter lab only once, which update the notebook metadata and fixes the issue.

This PR simply update the notebook containing widgets.

More details: https://github.com/jupyter/nbformat/issues/161#issuecomment-577412867