### PR TITLE
Improve environment file 

### DIFF
--- a/environment-all.yml
+++ b/environment-all.yml
@@ -2,8 +2,6 @@ name: hyperspy
 channels:
   - conda-forge
 dependencies:
-  - hyperspy-base
-  - hyperspy-gui-ipywidgets
+  - hyperspy
   - ipympl
-  - scikit-learn
 


### PR DESCRIPTION
- Improve environment file so that it can be used to create environment and not only update an already existing environment.
- The `environment.yml` is used by binder and has minimum dependency requirement (not qt, etc.) to run on binder, the `environment-all.yml` is manual install targeting user familiar with environment file and will install all dependencies as defined by the hyperspy meta-package on conda-forge.