### PR TITLE
bump version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,8 +2,8 @@ name: hyperspy
 channels:
   - conda-forge
 dependencies:
-  - hyperspy-base
-  - hyperspy-gui-ipywidgets
+  - hyperspy-base>=1.7.0
+  - hyperspy-gui-ipywidgets>=1.5.0
   - ipympl
   - scikit-learn
 


### PR DESCRIPTION
Explicitly set dependency versions to be able to force binder to rebuilt by updating dependency version.